### PR TITLE
feat(readme): add setup instructions for OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@
 go install github.com/ak9024/go-commit@latest
 ```
 
+### Setup
+
+```bash
+export OPENAI_API_KEY=<token>
+
+# or open file ~/.zshrc
+# add "export OPENAI_API_KEY=<token>"
+# source ~/.zshrc
+```
+
 ### How to run?
 
 ```bash


### PR DESCRIPTION
- Added setup instructions for configuring the  environment variable.
- Instructions include exporting the key using the declare -x DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/1000/bus"
- Updated the README.md file with the new instructions.