### PR TITLE
feat(commit): add spinner to handle buffering while async process

### DIFF
--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -24,13 +24,13 @@ func Commit(cmd *cobra.Command, args []string) {
 
 	if _cmd == "" {
 		generatedFigure.Print()
-		utils.Print("Oops", "Please doing git add <file> first or make sure git init in your repository")
+		utils.Print("Invalid", "Can't be execute git diff --staged")
 		os.Exit(0)
 	}
 
+	// add spinner to handle buffering while async process
 	s := spinner.New(spinner.CharSets[32], 100*time.Millisecond)
 	s.Start()
-	s.Prefix = "waiting.. "
 	s.HideCursor = true
 
 	// get `stdout` from `_cmd` and pass to chatgpt.GeneratedCommitMessageByChatGPT.
@@ -40,21 +40,29 @@ func Commit(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}
 
+	// stop the spinner if the data return
 	s.Stop()
 
+	// get message generate from chatgpt
 	commitMessage := out.Choices[len(out.Choices)-1].Message.Content
 
+	// present the result, before commit happened
 	generatedFigure.Print()
-	utils.Print("Please review your commit message", commitMessage)
+	utils.Print("Please review your commit message:", commitMessage)
 
-	// ask a quetion to make sure the commit suitable with the changes
-	commit := utils.StringPrompt("[Ask] If ok, please confirm to commit [y/n]? ")
+	// ask a quetion to confirm, before commit execute
+	confirmCommit := utils.StringPrompt("[Confirm] If ok, please confirm to execute commit [y/n]? ")
 
-	if commit != "" && strings.EqualFold(commit, "y") {
+	// validate just process commit, if user aggre for the next action (commit)
+	if confirmCommit != "" && strings.EqualFold(confirmCommit, "y") {
+		// compose the command for commit
 		gitCommit := fmt.Sprintf(`git commit -m "%s"`, commitMessage)
+		// exec the command for commit
 		execCommit, _ := utils.ExecCommand(gitCommit)
+		// present the result
 		fmt.Println(execCommit)
 	} else {
+		// close all the process if user ignore to commit
 		os.Exit(0)
 	}
 

--- a/pkg/chatgpt/commit.go
+++ b/pkg/chatgpt/commit.go
@@ -16,12 +16,15 @@ func GeneratedCommitMessageByChatGPT(c string) (*sdk.ModelChatResponse, error) {
 
 	generatedFigure := figure.NewFigure("go-commit", "", true)
 
+	// if OpenAIKey not, print the error message and close the process
 	if OpenAIKey == "" {
 		generatedFigure.Print()
-		utils.Print("Oops", "Please setup OPENAI_API_KEY in your environment")
+		utils.Print("OPENAI_API_KEY not found!", "Please setup OPENAI_API_KEY in your environment")
 		os.Exit(0)
 	}
 
+	// @TODO
+	// next time need to add more config like chatgpt model
 	resp, err := _sdk.ChatCompletions(sdk.ModelChat{
 		Model: "gpt-3.5-turbo",
 		Messages: []sdk.Message{


### PR DESCRIPTION
- Added a spinner to handle buffering while the async process is running. This spinner is used to provide a visual indication to the user that the process is still ongoing.
- The spinner is started before executing the command and stopped once the data is returned.
- The spinner is configured to use a specific character set and a delay of 100 milliseconds between each frame.
- The cursor is hidden during the spinner execution to improve the user experience.

fix(commit): print appropriate error message when _cmd is empty

- When  is empty, an appropriate error message is now printed instead of the Oops message.
- The new error message states that the command diff --git a/internal/commit/commit.go b/internal/commit/commit.go index 5b7d52c..2067779 100644
--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -24,13 +24,13 @@ func Commit(cmd *cobra.Command, args []string) {

 	if _cmd == "" {
 		generatedFigure.Print()
-		utils.Print("Oops", "Please doing git add <file> first or make sure git init in your repository")
+		utils.Print("Invalid", "Can't be execute git diff --staged") os.Exit(0) }

+	// add spinner to handle buffering while async process s := spinner.New(spinner.CharSets[32], 100*time.Millisecond) s.Start()
-	s.Prefix = "waiting.. " s.HideCursor = true

 	// get `stdout` from `_cmd` and pass to chatgpt.GeneratedCommitMessageByChatGPT. @@ -40,21 +40,29 @@ func Commit(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}

+	// stop the spinner if the data return s.Stop()

+	// get message generate from chatgpt commitMessage := out.Choices[len(out.Choices)-1].Message.Content

+	// present the result, before commit happened generatedFigure.Print()
-	utils.Print("Please review your commit message", commitMessage)
+	utils.Print("Please review your commit message:", commitMessage)

-	// ask a quetion to make sure the commit suitable with the changes
-	commit := utils.StringPrompt("[Ask] If ok, please confirm to commit [y/n]? ")
+	// ask a quetion to confirm, before commit execute
+	confirmCommit := utils.StringPrompt("[Confirm] If ok, please confirm to execute commit [y/n]? ")

-	if commit != "" && strings.EqualFold(commit, "y") {
+	// validate just process commit, if user aggre for the next action (commit)
+	if confirmCommit != "" && strings.EqualFold(confirmCommit, "y") {
+		// compose the command for commit gitCommit := fmt.Sprintf(`git commit -m "%s"`, commitMessage)
+		// exec the command for commit execCommit, _ := utils.ExecCommand(gitCommit)
+		// present the result fmt.Println(execCommit) } else {
+		// close all the process if user ignore to commit os.Exit(0) }

diff --git a/pkg/chatgpt/commit.go b/pkg/chatgpt/commit.go index 55d2abc..057d30b 100644
--- a/pkg/chatgpt/commit.go
+++ b/pkg/chatgpt/commit.go
@@ -16,12 +16,15 @@ func GeneratedCommitMessageByChatGPT(c string) (*sdk.ModelChatResponse, error) {

 	generatedFigure := figure.NewFigure("go-commit", "", true)

+	// if OpenAIKey not, print the error message and close the process if OpenAIKey == "" { generatedFigure.Print()
-		utils.Print("Oops", "Please setup OPENAI_API_KEY in your environment")
+		utils.Print("OPENAI_API_KEY not found!", "Please setup OPENAI_API_KEY in your environment") os.Exit(0) }

+	// @TODO
+	// next time need to add more config like chatgpt model resp, err := _sdk.ChatCompletions(sdk.ModelChat{ Model: "gpt-3.5-turbo", Messages: []sdk.Message{ cannot be executed.

chore(commit): update figure and print commit message

- Updated the ASCII art figure displayed before printing the commit message.
- The commit message obtained from  is now printed