### PR TITLE
chore(cmd): add constant.go

### DIFF
--- a/cmd/constant.go
+++ b/cmd/constant.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ak9024/go-commit/utils"
+)
+
+var (
+	cliVersion = "v0.1.2"
+	shortText  = "The CLI (Command Line Interface) helps you generate commits automatically"
+	longText   = "The CLI (Command Line Interface) helps you generate commits automatically, using karma style for git convention"
+	Long       = fmt.Sprintf(`
+%s
+%s
+	`,
+		utils.PrintLogo(),
+		longText,
+	)
+)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,17 +8,16 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "go-commit",
-	Short: "The CLI (Command Line Interface) helps you generate commits automatically",
-	Long:  "The CLI (Command Line Interface) helps you generate commits automatically, using karma style for git convention",
+	Use:     "go-commit",
+	Version: cliVersion,
+	Short:   shortText,
+	Long:    Long,
 }
 
 func Execute() {
 	rootCmd.AddCommand(commitCmd)
-
 	// to enable suggestions
 	rootCmd.SuggestionsMinimumDistance = 1
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(0)

--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -59,11 +60,7 @@ func Commit(cmd *cobra.Command, args []string) {
 		gitCommit := fmt.Sprintf(`git commit -m "%s"`, commitMessage)
 		// exec the command for commit
 		execCommit, _ := utils.ExecCommand(gitCommit)
-
-		if execCommit != "" {
-			fmt.Println("success to commit.., please check with go log")
-		}
-
+		log.Println(execCommit)
 		return
 	}
 

--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -59,8 +59,10 @@ func Commit(cmd *cobra.Command, args []string) {
 		gitCommit := fmt.Sprintf(`git commit -m "%s"`, commitMessage)
 		// exec the command for commit
 		execCommit, _ := utils.ExecCommand(gitCommit)
-		// present the result
-		fmt.Println(execCommit)
+
+		if execCommit != "" {
+			fmt.Println("success to commit.., please check with go log")
+		}
 
 		return
 	}

--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ak9024/go-commit/pkg/chatgpt"
 	"github.com/ak9024/go-commit/utils"
 	"github.com/briandowns/spinner"
-	"github.com/common-nighthawk/go-figure"
 	"github.com/spf13/cobra"
 )
 
@@ -17,15 +16,15 @@ func Commit(cmd *cobra.Command, args []string) {
 	_cmd, err := utils.ExecCommand("git diff --staged")
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(0)
+
+		return
 	}
 
-	generatedFigure := figure.NewFigure("go-commit", "", true)
-
 	if _cmd == "" {
-		generatedFigure.Print()
-		utils.Print("Invalid", "Can't be execute git diff --staged")
-		os.Exit(0)
+		fmt.Println(utils.PrintLogo())
+		utils.Print("Invalid", "Can't be execute git diff --staged, please execute git add before commit")
+
+		return
 	}
 
 	// add spinner to handle buffering while async process
@@ -37,7 +36,8 @@ func Commit(cmd *cobra.Command, args []string) {
 	out, err := chatgpt.GeneratedCommitMessageByChatGPT(_cmd)
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(0)
+
+		return
 	}
 
 	// stop the spinner if the data return
@@ -47,7 +47,7 @@ func Commit(cmd *cobra.Command, args []string) {
 	commitMessage := out.Choices[len(out.Choices)-1].Message.Content
 
 	// present the result, before commit happened
-	generatedFigure.Print()
+	fmt.Println(utils.PrintLogo())
 	utils.Print("Please review your commit message:", commitMessage)
 
 	// ask a quetion to confirm, before commit execute
@@ -61,9 +61,10 @@ func Commit(cmd *cobra.Command, args []string) {
 		execCommit, _ := utils.ExecCommand(gitCommit)
 		// present the result
 		fmt.Println(execCommit)
-	} else {
-		// close all the process if user ignore to commit
-		os.Exit(0)
+
+		return
 	}
 
+	// close all the process if user ignore to commit
+	os.Exit(0)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,9 +35,9 @@ func ExecCommand(input string) (string, error) {
 	// return `stderr.String()`
 	if stderr.String() != "" {
 		return stderr.String(), nil
-	} else {
-		return stdout.String(), nil
 	}
+
+	return stdout.String(), nil
 }
 
 // stringPrompt(input string) to handle prompt in terminal

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/common-nighthawk/go-figure"
 )
 
 // execCommand(input string) func to handle command
@@ -53,6 +55,11 @@ func StringPrompt(input string) string {
 	return strings.TrimSpace(s)
 }
 
+func PrintLogo() string {
+	f := figure.NewFigure("go-commit", "", true)
+	return f.String()
+}
+
 func Print(title, description string) {
 	fmt.Println()
 	fmt.Println()
@@ -60,8 +67,8 @@ func Print(title, description string) {
 	fmt.Println(fmt.Sprintf("[Info] %s", title))
 	fmt.Println()
 	fmt.Println("[Output]")
-	fmt.Println("---------------------------------------------------------------------------")
+	fmt.Println()
 	fmt.Println(description)
-	fmt.Println("---------------------------------------------------------------------------")
+	fmt.Println()
 	fmt.Println()
 }


### PR DESCRIPTION
Add a new file constant.go to the cmd package. This file contains constants used in the command line interface (CLI) for generating commits automatically.

The constants include:
- cliVersion: the current version of the CLI
- shortText: a short description of the CLI
- longText: a longer description of the CLI and its usage

This file will be used to store constant values that are used across the CLI.

chore(cmd): update root.go

Update the root.go file in the cmd package.

- Set the CLI name to go-commit.
- Set the CLI version to the value stored in the cliVersion constant.
- Set the short description of the CLI to the value stored in the shortText constant.
- Set the long description of the CLI to the value stored in the Long constant.

These updates ensure that the CLI is properly named and versioned, and that