### PR TITLE
chore(utils): refactor print function to remove unnecessary println statements

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -63,8 +63,8 @@ func PrintLogo() string {
 func Print(title, description string) {
 	fmt.Println()
 	fmt.Println()
-	fmt.Println(fmt.Sprintf("[Time] %s", time.TimeOnly))
-	fmt.Println(fmt.Sprintf("[Info] %s", title))
+	fmt.Printf("[Time] %s", time.TimeOnly)
+	fmt.Printf("[Info] %s", title)
 	fmt.Println()
 	fmt.Println("[Output]")
 	fmt.Println()


### PR DESCRIPTION
Refactor the  function in  to remove unnecessary  statements. The  function now uses  instead of  to print the time and info. This change improves code readability and reduces unnecessary new lines in the output.
